### PR TITLE
Updated paths and removed a variable

### DIFF
--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -1,8 +1,8 @@
 [defaults]
 # Additional plugins
-lookup_plugins = /opt/openstack-ansible/playbooks/plugins/lookups
-filter_plugins = /opt/openstack-ansible/playbooks/plugins/filters
-action_plugins = /opt/openstack-ansible/playbooks/plugins/actions
+lookup_plugins = /etc/ansible/plugins/lookup
+filter_plugins = /etc/ansible/plugins/filter
+action_plugins = /etc/ansible/plugins/actions
 
 gathering = smart
 

--- a/playbooks/roles/horizon_metadata_plugin/defaults/main.yml
+++ b/playbooks/roles/horizon_metadata_plugin/defaults/main.yml
@@ -3,6 +3,5 @@ horizon_metadata_plugin_git_branch: v1.0.0
 horizon_metadata_plugin_dest_dir: /opt/rackspace/horizon_metadata_plugin
 
 # Mitaka 
-openstack_release: 13.2.0
 horizon_venv_bin: "/openstack/venvs/horizon-{{ openstack_release }}/bin"
 horizon_venv_lib_dir: "{{ horizon_venv_bin | dirname }}/lib/python2.7/site-packages"


### PR DESCRIPTION
Updated the paths in the ansible.cfg to point
at the locations for mitaka + in OSA
Removed the openstack release variable because its
pulled in using the inventory with these corrected paths
