### PR TITLE
Changed priority on an enabled script.

### DIFF
--- a/playbooks/roles/horizon_metadata_plugin/tasks/main.yml
+++ b/playbooks/roles/horizon_metadata_plugin/tasks/main.yml
@@ -54,7 +54,7 @@
   with_items:
     - { src: "{{ horizon_venv_lib_dir }}/horizon_metadata_plugin/enabled/_1040_project_volumes_panel.py", dest: "{{ horizon_venv_lib_dir }}/openstack_dashboard/enabled/_1040_project_volumes_panel.py" }
     - { src: "{{ horizon_venv_lib_dir }}/horizon_metadata_plugin/enabled/_1050_project_images_panel.py", dest: "{{ horizon_venv_lib_dir }}/openstack_dashboard/enabled/_1050_project_images_panel.py" }
-    - { src: "{{ horizon_venv_lib_dir }}/horizon_metadata_plugin/enabled/_3100_add_container_meta_panel.py", dest: "{{ horizon_venv_lib_dir }}/openstack_dashboard/local/enabled/_3100_add_container_meta_panel.py" }
+    - { src: "{{ horizon_venv_lib_dir }}/horizon_metadata_plugin/enabled/_3100_add_container_meta_panel.py", dest: "{{ horizon_venv_lib_dir }}/openstack_dashboard/local/enabled/_1477_add_container_meta_panel.py" }
     - { src: "{{ horizon_venv_lib_dir }}/horizon_metadata_plugin/enabled/_60_remove_container_panel.py", dest: "{{ horizon_venv_lib_dir }}/openstack_dashboard/local/enabled/_60_remove_container_panel.py" }
   notify: Restart apache2
   tags:


### PR DESCRIPTION
This is a workaround to a problem caused with openstack-ansible
and the neutron_lbaas_dashboard horizon plugin.

When this enabled script is a higher priority, the lbaas panel
does not work correctly.

This changed se tthe priority from _3100 to _1477 which is < 1481.